### PR TITLE
Downgrade to Starscream `3.1.0`.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,12 +12,11 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(name: "web3swift", targets: ["web3swift"]),
     ],
-    
     dependencies: [
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.2.0"),
         .package(url: "https://github.com/mxcl/PromiseKit.git", from: "6.15.3"),
-        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.4"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.4.0"),
+        .package(url: "https://github.com/daltoniam/Starscream.git", .upToNextMinor(from: "3.1.0")),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.4.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/web3swift/Web3/Web3+WebsocketProvider.swift
+++ b/Sources/web3swift/Web3/Web3+WebsocketProvider.swift
@@ -93,10 +93,6 @@ public protocol Web3SocketDelegate {
 /// The default websocket provider.
 public class WebsocketProvider: Web3Provider, IWebsocketProvider, WebSocketDelegate {
     
-    public func didReceive(event: WebSocketEvent, client: WebSocket) {
-        
-    }
-    
     public func sendAsync(_ request: JSONRPCrequest, queue: DispatchQueue) -> Promise<JSONRPCresponse> {
         return Promise(error: Web3Error.inputError(desc: "Sending is unsupported for Websocket provider. Please, use \'sendMessage\'"))
     }

--- a/web3swift-zksync.podspec
+++ b/web3swift-zksync.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |spec|
-    spec.name         = 'web3swift'
-    spec.version      = '2.3.0'
+    spec.name         = 'web3swift-zksync'
+    spec.version      = '2.4.0-zksync'
     spec.ios.deployment_target = "9.0"
-    spec.osx.deployment_target = "10.11"
+    spec.osx.deployment_target = "10.12"
     spec.license      = { :type => 'Apache License 2.0', :file => 'LICENSE.md' }
     spec.summary      = 'Web3 implementation in vanilla Swift for iOS, macOS, and Linux'
-    spec.homepage     = 'https://github.com/matter-labs/web3swift'
+    spec.homepage     = 'https://github.com/zksync-sdk/web3swift'
     spec.author       = {"Alex Vlasov" => "alex.m.vlasov@gmail.com", "Anton Grigorev" => "antongrigorjev2010@gmail.com", "Petr Korolev" => "sky4winder@gmail.com"}
-    spec.source       = { :git => 'https://github.com/matter-labs/web3swift.git', :tag => spec.version.to_s }
+    spec.source       = { :git => 'https://github.com/zksync-sdk/web3swift.git', :tag => spec.version.to_s }
     spec.source_files = "Sources/web3swift/{Contract,Convenience,EthereumABI,EthereumAddress,HookedFunctions,KeystoreManager,Promises,SwiftRLP,Transaction,Web3}/*.swift", "Sources/web3swift/{Tokens,Utils}/**/*.swift"
     spec.ios.source_files   = 'Sources/web3swift/Browser/*.swift'
     spec.resource_bundle = { "Browser" => "Sources/web3swift/Browser/*.js" }

--- a/web3swift.xcodeproj/project.pbxproj
+++ b/web3swift.xcodeproj/project.pbxproj
@@ -1214,7 +1214,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/opt/homebrew/bin/carthage copy-frameworks\n";
+			shellScript = "carthage copy-frameworks\n";
 		};
 		139751F0219AFA500044D2B0 /* Carthage */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Downgrade to Starscream `3.1.0` to prevent library mismatch issues.